### PR TITLE
release(v0.1.0-alpha.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+## [ 0.1.0-alpha.0](https://github.com///releases/tag/v0.1.0-alpha.0) (2025-10-31)
+
+Welcome to the v0.1.0-alpha.0 release of !
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com///issues.
+
+### Contributors
+
+* Fritz Schaal
+* Spencer Smith
+
+### Changes
+<details><summary>3 commits</summary>
+<p>
+
+* [`bfd17d0`](https://github.com///commit/bfd17d0a24365bcd6824bd1926068002f61e458e) chore: kresify this repo
+* [`0104de0`](https://github.com///commit/0104de0b6cb0d5dbcedc6ab032bfffa422f71a0a) chore: fixes from review
+* [`015f22a`](https://github.com///commit/015f22a07967aa9e4d7789edd38a010a9468ae9b) initial
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+


### PR DESCRIPTION
This is the official v0.1.0-alpha.0 release.