### PR TITLE
chore: add support for darwin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-31T15:20:18Z by kres cd5a938.
+# Generated on 2025-11-04T12:33:37Z by kres cd5a938.
 
 *
 !api
@@ -9,6 +9,7 @@
 !go.mod
 !go.sum
 !.golangci.yml
+!CHANGELOG.md
 !README.md
 !.markdownlint.json
 !hack/govulncheck.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-31T15:20:18Z by kres cd5a938.
+# Generated on 2025-11-04T12:33:37Z by kres cd5a938.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -210,3 +210,10 @@ jobs:
       - name: unit-tests-race
         run: |
           make unit-tests-race
+      - name: coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: _out/coverage-unit-tests.txt
+          flags: unit-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+        timeout-minutes: 3

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Generated on 2025-10-28T13:39:47Z by kres 46e133d.
 
 _out
+.vscode

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1,3 +1,18 @@
+kind: golang.Build
+spec:
+  outputs:
+    linux-amd64:
+      GOOS: linux
+      GOARCH: amd64
+    linux-arm64:
+      GOOS: linux
+      GOARCH: arm64
+    darwin-amd64:
+      GOOS: darwin
+      GOARCH: amd64
+    darwin-arm64:
+      GOOS: darwin
+      GOARCH: arm64
 ---
 kind: golang.Generate
 spec:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-31T15:20:18Z by kres cd5a938.
+# Generated on 2025-11-04T12:33:37Z by kres cd5a938.
 
 # common variables
 
@@ -198,6 +198,20 @@ unit-tests:  ## Performs unit tests
 unit-tests-race:  ## Performs unit tests with race detection enabled.
 	@$(MAKE) target-$@
 
+.PHONY: $(ARTIFACTS)/omni-infra-provider-libvirt-darwin-amd64
+$(ARTIFACTS)/omni-infra-provider-libvirt-darwin-amd64:
+	@$(MAKE) local-omni-infra-provider-libvirt-darwin-amd64 DEST=$(ARTIFACTS)
+
+.PHONY: omni-infra-provider-libvirt-darwin-amd64
+omni-infra-provider-libvirt-darwin-amd64: $(ARTIFACTS)/omni-infra-provider-libvirt-darwin-amd64  ## Builds executable for omni-infra-provider-libvirt-darwin-amd64.
+
+.PHONY: $(ARTIFACTS)/omni-infra-provider-libvirt-darwin-arm64
+$(ARTIFACTS)/omni-infra-provider-libvirt-darwin-arm64:
+	@$(MAKE) local-omni-infra-provider-libvirt-darwin-arm64 DEST=$(ARTIFACTS)
+
+.PHONY: omni-infra-provider-libvirt-darwin-arm64
+omni-infra-provider-libvirt-darwin-arm64: $(ARTIFACTS)/omni-infra-provider-libvirt-darwin-arm64  ## Builds executable for omni-infra-provider-libvirt-darwin-arm64.
+
 .PHONY: $(ARTIFACTS)/omni-infra-provider-libvirt-linux-amd64
 $(ARTIFACTS)/omni-infra-provider-libvirt-linux-amd64:
 	@$(MAKE) local-omni-infra-provider-libvirt-linux-amd64 DEST=$(ARTIFACTS)
@@ -205,8 +219,15 @@ $(ARTIFACTS)/omni-infra-provider-libvirt-linux-amd64:
 .PHONY: omni-infra-provider-libvirt-linux-amd64
 omni-infra-provider-libvirt-linux-amd64: $(ARTIFACTS)/omni-infra-provider-libvirt-linux-amd64  ## Builds executable for omni-infra-provider-libvirt-linux-amd64.
 
+.PHONY: $(ARTIFACTS)/omni-infra-provider-libvirt-linux-arm64
+$(ARTIFACTS)/omni-infra-provider-libvirt-linux-arm64:
+	@$(MAKE) local-omni-infra-provider-libvirt-linux-arm64 DEST=$(ARTIFACTS)
+
+.PHONY: omni-infra-provider-libvirt-linux-arm64
+omni-infra-provider-libvirt-linux-arm64: $(ARTIFACTS)/omni-infra-provider-libvirt-linux-arm64  ## Builds executable for omni-infra-provider-libvirt-linux-arm64.
+
 .PHONY: omni-infra-provider-libvirt
-omni-infra-provider-libvirt: omni-infra-provider-libvirt-linux-amd64  ## Builds executables for omni-infra-provider-libvirt.
+omni-infra-provider-libvirt: omni-infra-provider-libvirt-darwin-amd64 omni-infra-provider-libvirt-darwin-arm64 omni-infra-provider-libvirt-linux-amd64 omni-infra-provider-libvirt-linux-arm64  ## Builds executables for omni-infra-provider-libvirt.
 
 .PHONY: lint-markdown
 lint-markdown:  ## Runs markdownlint.

--- a/README.md
+++ b/README.md
@@ -2,33 +2,42 @@
 
 Can be used to automatically provision Talos nodes in `libvirtd`.
 
-## Running Infrastructure Provider
+## Configuration
 
-Create the configuration file for the provider.
+In your Omni instance under Settings -> Infra Providers, create a new `libvirt` provider.
+Make a note of the `OMNI_ENDPOINT` and `OMNI_SERVICE_ACCOUNT_KEY`.
+
+We now show various ways to connect to libvirt.
 For more options see the [libvirt URI docs](https://libvirt.org/uri.html)
 
-### connect to libvirt via ssh
+### Connecting to libvirt via ssh
 
-you must ensure to mount the proper SSH keys.
-this also requires the SSH user to have access to libvirt on the server side.
+You must ensure to mount the proper SSH keys.
+This also requires the SSH user to have access to libvirt on the server side.
+
+Create the configuration file for the provider:
 
 ```yaml
 libvirt:
   uri: 'qemu+libssh://user@hostname/system?known_hosts_verify=ignore'
 ```
 
-### connect to libvirt via socket
+### Connecting to libvirt via socket
 
-this requires to mount the libvirt socket into the container.
+If using Docker, this requires to mount the libvirt socket into the container.
 
 ```yaml
 libvirt:
   uri: 'qemu:///system'
+  # If using libvirt via Homebrew on MacOS:
+  # url: 'qemu:///session?socket=/Users/<username>/.cache/libvirt/libvirt-sock'
 ```
+
+## Running the provider
 
 ### Using Docker
 
-copy the provider credentials created in omni to an `.env` file
+Copy the provider credentials created in omni to an `.env` file
 
 ```env
 # your omni instance URL
@@ -37,7 +46,7 @@ OMNI_ENDPOINT=https://<OMNI_INSTANCE_NAME>.<REGION>.omni.siderolabs.io
 OMNI_SERVICE_ACCOUNT_KEY=<PROVIDER_KEY>
 ```
 
-example for using the above `ssh` based connection method:
+Example for using the above `ssh` based connection method:
 
 ```shell
 docker run \
@@ -52,7 +61,7 @@ docker run \
     --config-file /config.yaml
 ```
 
-example for using the above `socket` based connection method:
+Example for using the above `socket` based connection method:
 
 > **_NOTE:_**
 > don't blindly copy-paste this, the location might vary depending on your linux distribution.
@@ -71,16 +80,23 @@ docker run \
     --config-file /config.yaml
 ```
 
-## how to use in omni cluster templates
+## How to use in an Omni cluster templates
 
-see [test/](./test/) for some examples
+See [test/](./test/) for some examples
 
-## development
+## Development
 
-see `make help` for general build info.
+See `make help` for general build info.
 
-build an image:
+Build an image:
 
 ```shell
 make generate image-omni-infra-provider-libvirt-linux-amd64
+```
+
+Build the binary:
+
+```shell
+# e.g. for darwin
+make omni-infra-provider-libvirt-darwin-arm64
 ```


### PR DESCRIPTION
- Update the kres configuration to support Darwin builds. e.g. to build
  the binary:
```sh
make omni-infra-provider-libvirt-darwin-arm64
```
- Update documentation for MacOS

Signed-off-by: Andrew Longwill <andrew.longwill@siderolabs.com>
