### PR TITLE
chore: support darwin

### DIFF
--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -1,0 +1,30 @@
+# MacOS
+
+## Configuring storage
+
+```sh
+mkdir -p libvirt-storage
+virsh pool-define-as --name default --type dir --target "$(pwd)/libvirt-storage"
+virsh pool-start default
+virsh pool-autostart default
+```
+
+## Configure libvirt
+
+```sh
+export LIBVIRT_CPU_MAP_PATH=/opt/homebrew/share/libvirt/cpu_map
+brew services restart libvirt
+```
+
+Without this you may see this error:
+
+```text
+failed to start VM: Failed to open file '/opt/homebrew/Cellar/libvirt/11.9.0/share/libvirt/cpu_map/index.xml': No such file or directory
+```
+
+## Misc commands for interacting with libvirt
+
+```
+LIBVIRT_DEFAULT_URI="qemu:///session"
+virsh list --all
+```


### PR DESCRIPTION
Makes some changes so the VMs can run on MacOS.

N.B. This doesn't fully work. The VMs get provisioned, but do not connect to Omni.

Next step to try is to add a kernel arg `console=ttyAMA0` so the console is viewable via `virsh console <domain>`.
The VM may also not be working as `user-mode` networking was recommended by ChatGPT.

Signed-off-by: Andrew Longwill <andrew.longwill@siderolabs.com>
